### PR TITLE
Support for different syntaxes

### DIFF
--- a/addcopyright.sh
+++ b/addcopyright.sh
@@ -1,8 +1,55 @@
 #!/bin/bash
 
-## Solution found as part of this stackoverflow discussion: https://stackoverflow.com/questions/151677/tool-for-adding-license-headers-to-source-files
+declare -A applyRE
+declare -A addpre
+declare -A addpost
 
-for x in $*; do  
-head -$COPYRIGHTLEN $x | diff copyright.txt - || ( ( cat copyright.txt; echo; cat $x) > /tmp/file;  
-mv /tmp/file $x )  
-done 
+addpre[c]='/*'
+applyRE[c]='s/^/ * /'
+addpost[c]=' */'
+
+applyRE[shell]='s/^/# /'
+applyRE[matlab]='s/^/% /'
+applyRE[lua]='s/^/-- /'
+
+if [[ x$1 == x ]]; then
+    echo 'Must provide comments style as first argument' >&2
+    exit 1
+elif [[ -v "applyRE[$1]" ]] ; then
+    STYLE=$1
+else
+    echo "Unknown style"
+    exit 2
+fi
+
+if [[ x$2 == x ]]; then
+    # Apply to all files, excluding directories
+    FILES=$(find . -type f)
+else
+    D=$(dirname "$2")
+    F="${2#${D}/}"
+    FILES=$(find $D -type f -name "$F" -print)
+fi
+
+
+tmpcopyright=$(mktemp /tmp/addcopyright.XXXXXX)
+
+if [[ -v "addpre[$STYLE]" ]] ; then echo "${addpre[$STYLE]}" > $tmpcopyright ; fi
+sed "${applyRE[$STYLE]}" < copyright.txt >> $tmpcopyright
+if [[ -v "addpost[$STYLE]" ]] ; then echo "${addpost[$STYLE]}" >> $tmpcopyright; fi
+COPYRIGHTLEN=$(wc -l < $tmpcopyright)
+
+# Solution found as part of this stackoverflow discussion:
+# https://stackoverflow.com/questions/151677/tool-for-adding-license-headers-to-source-files
+for x in $FILES; do
+    tmpsrcfile=$(mktemp /tmp/addcopyright.XXXXXX)
+    head -$COPYRIGHTLEN $x | diff -q $tmpcopyright - > /dev/null
+    if [[ $? == 1 ]]; then
+	(cat $tmpcopyright; cat $x) > $tmpsrcfile
+	mv $tmpsrcfile $x
+    fi
+done
+
+#rm -f $tmpcopyright $tmpsrcfile
+
+exit 0

--- a/copyright.txt
+++ b/copyright.txt
@@ -1,9 +1,7 @@
-﻿/*
- © Copyright 2020 tapasadhikary.com or one of its affiliates.
- * Some Sample Copyright Text Line
- * Some Sample Copyright Text Line
- * Some Sample Copyright Text Line
- * Some Sample Copyright Text Line
- * Some Sample Copyright Text Line
- * Some Sample Copyright Text Line
-*/
+(c) Copyright 2022 tapasadhikary.com or one of its affiliates.
+Some Sample Copyright Text Line
+Some Sample Copyright Text Line
+Some Sample Copyright Text Line
+Some Sample Copyright Text Line
+Some Sample Copyright Text Line
+Some Sample Copyright Text Line

--- a/drill/abcd.js
+++ b/drill/abcd.js
@@ -4,3 +4,4 @@ const abcd = () => {
 }
 
 abcd();
+

--- a/drill/abcd.py
+++ b/drill/abcd.py
@@ -1,0 +1,5 @@
+
+def abcd():
+    print('abcd')
+
+abcd()

--- a/test.js
+++ b/test.js
@@ -1,15 +1,16 @@
-﻿/*
- © Copyright 2020 tapasadhikary.com or one of its affiliates.
+/*
+ * (c) Copyright 2022 tapasadhikary.com or one of its affiliates.
  * Some Sample Copyright Text Line
  * Some Sample Copyright Text Line
  * Some Sample Copyright Text Line
  * Some Sample Copyright Text Line
  * Some Sample Copyright Text Line
  * Some Sample Copyright Text Line
-*/
+ */
 
-const test = () => {
-	console.log('test');
+const abcd = () => {
+	console.log('abcd');
 }
 
-test();
+abcd();
+

--- a/test.py
+++ b/test.py
@@ -1,0 +1,12 @@
+# (c) Copyright 2022 tapasadhikary.com or one of its affiliates.
+# Some Sample Copyright Text Line
+# Some Sample Copyright Text Line
+# Some Sample Copyright Text Line
+# Some Sample Copyright Text Line
+# Some Sample Copyright Text Line
+# Some Sample Copyright Text Line
+
+def abcd():
+    print('abcd')
+
+abcd()


### PR DESCRIPTION
Add a mechanism for defining different comment syntaxes. Use this mechanism to define shell and C style comments and add testcses for Python (shell style) and JS (C style). Add a mechanism for controlling which files to add the copyright statement to.
Update copyright statement to 2022 and remove the UTF-8 character to make it easier to get clean tests reghardless of locale.